### PR TITLE
bypass Jekyll in GH Pages

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Build
       run: |
         make -C docs html
+        touch docs/build/html/.nojekyll
 
     - name: Deploy
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'


### PR DESCRIPTION
The website is not rendered correctly, and I expect that this happens because of Jekyll.
More info here:
https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/

The same thing is done here:
https://github.com/antmicro/litex-rowhammer-tester/blob/master/.github/workflows/build-gh-pages.yml#L31

@tgorochowik 