### PR TITLE
copy docs recursively instead of an asterisk

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -33,8 +33,7 @@ jobs:
     - name: Deploy
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
       run: |
-        mkdir deploy
-        cp -r docs/build/html/* deploy
+        cp -r docs/build/html deploy
         cd deploy
         git init
         cp ../.git/config ./.git/config


### PR DESCRIPTION
`.nojekyll` file would be skippeed when using `cp *`, and `cp -r` should have been used instead.

@tgorochowik 