### PR TITLE
ci: use containers instead of installing texlive-full in each run

### DIFF
--- a/.github/scripts/latex.sh
+++ b/.github/scripts/latex.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -e
+
+apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+  python3-pip \
+  python3-setuptools \
+  python3-wheel
+
+cd $(dirname $0)/../../docs
+
+pip3 install --user -r requirements.txt
+
+cd build/latex
+LATEXMKOPTS='-interaction=nonstopmode' make
+cp *.pdf ../html/

--- a/.github/scripts/sphinx.sh
+++ b/.github/scripts/sphinx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname $0)/../../docs
+
+pip3 install --user -r requirements.txt
+
+make html latex

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -11,40 +11,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+      - uses: docker://btdi/sphinx:min
+        with:
+          args: ./.github/scripts/sphinx.sh
 
-    - name: Install dependencies
-      run: |
-          sudo apt-get update
-          sudo apt-get install -y texlive-full
-          python3 -m pip install -r docs/requirements.txt
+      - uses: docker://btdi/latex
+        with:
+          args: ./.github/scripts/latex.sh
 
-    - name: Generate documentation
-      run: |
-        cd docs
-        make html latexpdf
-        cp build/latex/*.pdf build/html/
+      - name: 'Upload artifact: Sphinx HTML and PDF'
+        uses: actions/upload-artifact@v3
+        with:
+          name: Documentation
+          path: docs/build/html
 
-    - uses: actions/upload-artifact@v3
-      with:
-        name: gh-page
-        path: docs/build/html
-
-    - name: Deploy to Github Pages
-      if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-      run: |
-        cd docs/build/html
-        touch .nojekyll
-        git init
-        cp ../../../.git/config ./.git/config
-        git add .
-        git config --local user.email "push@gha"
-        git config --local user.name "GHA"
-        git commit -am "update ${{ github.sha }}"
-        git push -u origin +HEAD:gh-pages
-        rm -rf .git
+      - name: Deploy to Github Pages
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: |
+          sudo chown -R $(whoami) docs
+          cd docs/build/html
+          touch .nojekyll
+          git init
+          cp ../../../.git/config ./.git/config
+          git add .
+          git config --local user.email "push@gha"
+          git config --local user.name "GHA"
+          git commit -am "update ${{ github.sha }}"
+          git push -u origin +HEAD:gh-pages
+          rm -rf .git


### PR DESCRIPTION
As done in Raviewer (see https://github.com/antmicro/raviewer/blob/main/.github/workflows/docs.yml), this PR uses containers instead of installing texlive-full in each run.