### PR TITLE
Improved output for LogicArray -> size()

### DIFF
--- a/topwrap/model/hdl_types.py
+++ b/topwrap/model/hdl_types.py
@@ -109,7 +109,7 @@ class LogicArray(Logic, Generic[_ArrayItemOrField]):
     @property
     def size(self):
         return self.item.size * reduce(
-            lambda a, b: (b.upper - b.lower) * a, self.dimensions, ElaboratableValue(0)
+            lambda a, b: (b.upper - b.lower) * a, self.dimensions, ElaboratableValue(1)
         )
 
     @override


### PR DESCRIPTION
This change makes the function's output interpretable as a mathematical function returning signal-width -1.

Some outputs of ports in the pwm-example:

**Before the change**: All equations equal zero.
(1 * ((AXI_ID_WIDTH-1 - 0) * **0**))
(1 * ((AXI_DATA_WIDTH-1 - 0) * **0**))
(1 * ((1 - 0) * **0**))

**After the change**: All equations equal signal-width -1.
(1 * ((AXI_ID_WIDTH-1 - 0) * **1**))
(1 * ((AXI_DATA_WIDTH-1 - 0) * **1**))
(1 * ((1 - 0) * **1**))