### PR TITLE
Fix #15: Add parameter visibility flag and hide parameters in KPM backend

### DIFF
--- a/topwrap/backend/kpm/specification.py
+++ b/topwrap/backend/kpm/specification.py
@@ -111,8 +111,17 @@ class KpmSpecificationBackend:
 
         for param in mod.parameters:
             val = param.default_value
+
+            # 1. Determine if this specific parameter should be invisible
+            is_hidden = hasattr(param, "visible") and not param.visible
+
+            # 2. Pass the 'hidden' attribute directly inside the builder method
             self._spec.add_node_type_property(
-                nid.name, param.name, KpmPropertyType.TEXT.value, "" if val is None else val.value
+                nid.name,
+                param.name,
+                KpmPropertyType.TEXT.value,
+                "" if val is None else val.value,
+                hidden=is_hidden
             )
 
         for intf in mod.interfaces:

--- a/topwrap/model/misc.py
+++ b/topwrap/model/misc.py
@@ -274,6 +274,7 @@ class Parameter(ModelBase):
 
     parent: Module
     name: VariableName
+    visible: bool = True
 
     #: If a value for this parameter was not provided
     #: during elaboration, this default will be used.


### PR DESCRIPTION
Closes #15

This pull request resolves the clutter of internal/unnecessary parameters on the graphical dataflow canvas:
1. Updated the Parameter class model in `misc.py` to include a default `visible` boolean flag.
2. Modified the node configuration generator loop inside `specification.py` to pass the `hidden=is_hidden` state parameter directly into `add_node_type_property()`.

This ensures that any parameter explicitly marked as non-visible is suppressed cleanly from rendering on the KPM visual interface canvas.
