### PR TITLE
Support multidimensional ports

### DIFF
--- a/docs/source/description_files.md
+++ b/docs/source/description_files.md
@@ -93,7 +93,8 @@ reset_domains:
 external: # specify the names of external ports and interfaces of the top module
 ports:
   out:
-    - {ext_port_name}
+    - name: {ext_port_name}
+      bound: [[dim0_high, dim1_low], ..., [dimN_high, dimN, low]]
   inout:
     - [{ip_name/hierarchy_name, port_name}]
 interfaces:
@@ -278,7 +279,7 @@ Each signal (for both port and interface definitions) can be specified in one of
 The signal is defined by a YAML object, with the following properties:
 
  - `name` (optional) - the name of the signal.
- - `bound` (optional) - the bounds of the bit range, determining the width.
+ - `bound` (optional) - the bounds of the signal. The signal can be multidimensional.
  - `slice` (optional) - the bounds of the slice bit range (only applicable to interface definitions).
  - `default` (optional) - default value to assign to this port if nothing is connected to it, applicable only to input ports.
  - `type` (optional) - the name of the type (defined in the `types` section) used for this signal

--- a/tests/tests_ir/backend/test_sv.py
+++ b/tests/tests_ir/backend/test_sv.py
@@ -18,6 +18,7 @@ from examples.soc.ir.design import top as soc_top
 from topwrap.backend.sv.backend import GeneratorNotImplementedError, SystemVerilogBackend
 from topwrap.backend.sv.common import serialize_select, serialize_type, sv_varname
 from topwrap.backend.sv.design import Design, _SystemVerilogDesignData
+from topwrap.frontend.yaml.design import DesignDescriptionFrontend
 from topwrap.interconnects.wishbone_rr import WishboneInterconnect, WishboneRRParams
 from topwrap.model.connections import (
     ConstantConnection,
@@ -374,6 +375,25 @@ class TestSystemVerilogDesignBackend:
 
 
 class TestSystemVerilogBackend:
+    def test_multidimensional_port_from_yaml(self):
+        design_yaml = """
+            name: top
+            external:
+              ports:
+                in:
+                  - name: in_arr
+                    bound: [[1, 0], [7, 0], [3, 0]]
+        """
+
+        design, _ = DesignDescriptionFrontend().parse_str(design_yaml)
+        backend = SystemVerilogBackend(desc_comms=False)
+        [output] = backend.serialize(backend.represent(design.parent), combine=True)
+
+        assert (
+            "module top (\n    input logic [1:0][7:0][3:0] in_arr\n);\n\nendmodule"
+            == output.content
+        )
+
     def test_repr_empty_package(self):
         back = SystemVerilogBackend(desc_comms=False)
 

--- a/tests/tests_ir/backend/test_yaml.py
+++ b/tests/tests_ir/backend/test_yaml.py
@@ -48,6 +48,7 @@ from topwrap.model.hdl_types import (
     Bits,
     BitStruct,
     Dimensions,
+    LogicArray,
     LogicBitSelect,
     LogicFieldSelect,
     LogicSelect,
@@ -265,6 +266,49 @@ class TestIpCoreDescriptionBackend:
                 ],
             },
         }
+
+    def test_multidimensional_port(self):
+        ty = Bits(
+            dimensions=[
+                Dimensions(upper=ElaboratableValue(1), lower=ElaboratableValue(0)),
+                Dimensions(upper=ElaboratableValue(7), lower=ElaboratableValue(0)),
+            ]
+        )
+
+        top = Module(
+            id=Identifier(name="top"),
+            ports=[
+                Port(
+                    name="foo",
+                    direction=PortDirection.IN,
+                    type=ty,
+                    default_value=ElaboratableValue(4),
+                ),
+            ],
+        )
+
+        backend = IpCoreDescriptionBackend()
+
+        out = backend.represent(top)
+        [out] = backend.serialize(out)
+        tree = yaml.safe_load(out.content)
+
+        assert tree == {
+            "id": {"name": "top", "library": "libdefault", "vendor": "vendor", "version": "0.1"},
+            "signals": {
+                "in": [
+                    {
+                        "name": "foo",
+                        "bound": [["1", "0"], ["7", "0"]],
+                        "default": "4",
+                    },
+                ],
+            },
+        }
+
+        frontend = IPCoreDescriptionFrontend()
+        mod = frontend.parse_str(out.content)
+        _compare_modules(top, mod)
 
     def test_parameters(self):
         mod = Module(
@@ -687,6 +731,42 @@ class TestDesignDescriptionBackend:
 
                         expected_obj: dict[str, str] = {name: h.to_str() for name, h in rep.items()}
                         assert repo_dict == expected_obj
+
+    def test_multidimensional_top_level_ports_roundtrip(self):
+        design_yaml = """
+            name: top
+            external:
+              ports:
+                in:
+                  - name: in_arr
+                    bound: [[1, 0], [7, 0], [3, 0]]
+                out:
+                  - name: out_vec
+                    bound: [[15, 0]]
+            """
+
+        front = DesignDescriptionFrontend()
+        orig_des, _ = front.parse_str(design_yaml)
+
+        back = DesignDescriptionBackend()
+        out = back.represent(orig_des.parent)
+        [out] = back.serialize(out)
+
+        new_des, _ = front.parse_str(out.content)
+
+        in_arr = new_des.parent.ports.find_by_name_or_error("in_arr")
+        out_vec = new_des.parent.ports.find_by_name_or_error("out_vec")
+
+        assert isinstance(in_arr.type, LogicArray)
+        assert in_arr.type.dimensions == [
+            Dimensions(upper=ElaboratableValue(1), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(7), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(3), lower=ElaboratableValue(0)),
+        ]
+        assert isinstance(out_vec.type, LogicArray)
+        assert out_vec.type.dimensions == [
+            Dimensions(upper=ElaboratableValue(15), lower=ElaboratableValue(0))
+        ]
 
 
 class TestDesignPositionsBackend:

--- a/tests/tests_ir/frontend/test_yaml.py
+++ b/tests/tests_ir/frontend/test_yaml.py
@@ -262,8 +262,68 @@ class TestDesignDescriptionFrontend:
                 assert all(type(out.config.repositories[k]) is type(rep[k]) for k in keys)
                 assert all(out.config.repositories[k].to_str() == rep[k].to_str() for k in keys)
 
+    def test_multidimensional_top_level_ports(self):
+        des = """
+        name: top
+        external:
+          ports:
+            in:
+              - name: in_arr
+                bound:
+                  - [1, 0]
+                  - [7, 0]
+                  - [3, 0]
+            out:
+              - name: out_vec
+                bound:
+                  - [15, 0]
+        """
+
+        mod, _ = DesignDescriptionFrontend().parse_str(des)
+
+        in_arr = mod.parent.ports.find_by_name_or_error("in_arr")
+        out_vec = mod.parent.ports.find_by_name_or_error("out_vec")
+
+        assert isinstance(in_arr.type, LogicArray)
+        assert in_arr.type.dimensions == [
+            Dimensions(upper=ElaboratableValue(1), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(7), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(3), lower=ElaboratableValue(0)),
+        ]
+        assert isinstance(out_vec.type, LogicArray)
+        assert out_vec.type.dimensions == [
+            Dimensions(upper=ElaboratableValue(15), lower=ElaboratableValue(0))
+        ]
+
 
 class TestIPCoreDescriptionFrontend:
+    def test_multidimensional_signal(self):
+        ip = """
+        id:
+          name: top
+          vendor: vendor
+          library: libdefault
+        signals:
+          in:
+            - name: in_arr
+              bound:
+                - [1, 0]
+                - [7, 0]
+                - [3, 0]
+              default: 4
+        """
+
+        mod = IPCoreDescriptionFrontend().parse_str(ip)
+        in_arr = mod.ports.find_by_name_or_error("in_arr")
+
+        assert isinstance(in_arr.type, LogicArray)
+        assert in_arr.type.dimensions == [
+            Dimensions(upper=ElaboratableValue(1), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(7), lower=ElaboratableValue(0)),
+            Dimensions(upper=ElaboratableValue(3), lower=ElaboratableValue(0)),
+        ]
+        assert in_arr.default_value == ElaboratableValue("4")
+
     def test_parse_on_mem_yaml(self):
         ip = Path("examples/ir_examples/interconnect/ips/mem.yaml")
         mod = IPCoreDescriptionFrontend().parse_file(ip)

--- a/topwrap/backend/yaml/backend.py
+++ b/topwrap/backend/yaml/backend.py
@@ -31,6 +31,7 @@ from topwrap.frontend.yaml.design_schema import (
     ConnectionsSection,
     DesignDescription,
     DesignExternalIntfs,
+    DesignExternalPortDefinition,
     DesignExternalPorts,
     DesignExternalSection,
     DesignInverterPosition,
@@ -157,10 +158,13 @@ class IpCoreDescriptionBackend(Backend[IpCoreDescriptionOutput]):
             if slice:
                 raise ValueError("Trying to slice a single bit")
         elif isinstance(type, Bits):
-            if len(type.dimensions) > 1:
-                raise ValueError("IP core YAML format only supports one-dimensional bit vectors")
-
             bound = (type.dimensions[0].upper.value, type.dimensions[0].lower.value)
+            if len(type.dimensions) > 1:
+                return IPCoreComplexSignal(
+                    name=name,
+                    bound=tuple((d.upper.value, d.lower.value) for d in type.dimensions),
+                    default=default.value if default else None,
+                )
         else:
             logger.warning(f"Got unexpected type {type} for signal in IP core YAML backend")
 
@@ -586,11 +590,19 @@ class DesignDescriptionBackend(Backend[DesignDescriptionOutput]):
         outputs = []
         inouts = []
 
+        def represent_port(port: Port):
+            if isinstance(port.type, LogicArray) and isinstance(port.type.item, Bit):
+                return DesignExternalPortDefinition(
+                    name=port.name,
+                    bound=[(dim.upper.value, dim.lower.value) for dim in port.type.dimensions],
+                )
+            return port.name
+
         for port in mod.non_intf_ports():
             if port.direction is PortDirection.IN:
-                inputs.append(port.name)
+                inputs.append(represent_port(port))
             elif port.direction is PortDirection.OUT:
-                outputs.append(port.name)
+                outputs.append(represent_port(port))
             elif port.direction is PortDirection.INOUT:
                 # Look for connection that this port is a part of, then from that
                 # find the module port it's connected to.

--- a/topwrap/backend/yaml/common/ip_core_schema.py
+++ b/topwrap/backend/yaml/common/ip_core_schema.py
@@ -15,6 +15,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
 import marshmallow
@@ -33,12 +34,14 @@ from topwrap.repo.exceptions import ResourceNotFoundException
 from topwrap.util import get_config, get_interface_by_id
 
 _StrOrInt = Union[str, int]
+IPCoreDimension = Tuple[_StrOrInt, _StrOrInt]
+IPCoreBounds = Union[IPCoreDimension, Tuple[IPCoreDimension, ...]]
 
 
 @marshmallow_dataclass.dataclass(frozen=True)
 class IPCoreComplexSignal(MarshmallowDataclassExtensions):
     name: Optional[str] = ext_field(None)
-    bound: Optional[tuple[_StrOrInt, _StrOrInt]] = ext_field(None)
+    bound: Optional[IPCoreBounds] = ext_field(None)
     slice: Optional[tuple[_StrOrInt, _StrOrInt]] = ext_field(None)
     default: Optional[_StrOrInt] = ext_field(None)
     path: Optional[PortSelectorT] = ext_field(None)
@@ -51,6 +54,9 @@ class IPCoreComplexSignal(MarshmallowDataclassExtensions):
 
         if self_obj["bound"] is not None and self_obj["type"] is not None:
             raise marshmallow.ValidationError("Signal requires either a bound or a type, not both")
+
+        if isinstance(self_obj["bound"], tuple) and len(self_obj["bound"]) == 0:
+            raise marshmallow.ValidationError("Signal dimensions cannot be empty")
 
         return True
 
@@ -93,11 +99,17 @@ class IPCorePort:
             name = sig.name if sig.name is not None else str(sig.path)
             assert name is not None
 
+            bounds = sig.bound
+            if bounds is not None and isinstance(bounds[0], tuple):
+                bounds = cast(IPCoreDimension, bounds[0])
+            elif bounds is not None:
+                bounds = cast(IPCoreDimension, bounds)
+
             return IPCorePort(
                 name=name,
                 direction=dir,
-                upper_bound=sig.bound[0] if sig.bound else 0,
-                lower_bound=sig.bound[1] if sig.bound else 0,
+                upper_bound=bounds[0] if bounds else 0,
+                lower_bound=bounds[1] if bounds else 0,
                 upper_slice=sig.slice[0] if sig.slice else 0,
                 lower_slice=sig.slice[1] if sig.slice else 0,
             )

--- a/topwrap/frontend/yaml/design.py
+++ b/topwrap/frontend/yaml/design.py
@@ -12,6 +12,7 @@ from topwrap.backend.kpm.common import Positions
 from topwrap.backend.yaml.common.ip_core_schema import param_to_ir_param
 from topwrap.frontend.yaml.design_schema import (
     DesignDescription,
+    DesignExternalPortDefinition,
     DesignIP,
     DesignNodePosition,
     DesignPositionDefinition,
@@ -36,7 +37,7 @@ from topwrap.model.connections import (
     ResetPolarity,
 )
 from topwrap.model.design import ClockDomain, Design, ModuleInstance, ResetDomain
-from topwrap.model.hdl_types import Bit
+from topwrap.model.hdl_types import Bit, Bits, Dimensions
 from topwrap.model.interconnect import Interconnect
 from topwrap.model.interface import Interface, InterfaceDefinition, InterfaceMode, InterfaceSignal
 from topwrap.model.memory_map import MemoryMap as IRMemoryMap
@@ -136,15 +137,38 @@ class DesignDescriptionFrontend:
             parsed, _ = self._parse_hier(source, hdesc, hname)
             design.add_component(ModuleInstance(name=hname, module=parsed.parent))
 
-    def _parse_ports(self, desc: DesignDescription) -> dict[str, tuple[PortDirection, bool]]:
+    # Parse external port names and determine if they are multidimensional
+    def _external_decl_name(self, decl: str | DesignExternalPortDefinition) -> str:
+        return decl if isinstance(decl, str) else decl.name
+
+    def _external_decl_type(self, decl: DesignExternalPortDefinition):
+        if len(decl.bound) == 0:
+            return Bit()
+        return Bits(
+            dimensions=[
+                Dimensions(ElaboratableValue(upper), ElaboratableValue(lower))
+                for upper, lower in decl.bound
+            ]
+        )
+
+    def _parse_ports(
+        self, desc: DesignDescription, mod: Module
+    ) -> dict[str, tuple[PortDirection, bool]]:
         declared_exts = dict[str, tuple[PortDirection, bool]]()
         for port, group in ((True, desc.external.ports), (False, desc.external.interfaces)):
             for dir, decls in ((PortDirection.IN, group.input), (PortDirection.OUT, group.output)):
                 for d in decls:
-                    if d in declared_exts:
-                        logger.warning(f"Skipping duplicated external IO: '{d}'")
+                    name = self._external_decl_name(d) if port else d
+                    if name in declared_exts:
+                        logger.warning(f"Skipping duplicated external IO: '{name}'")
                         continue
-                    declared_exts[d] = (dir, port)
+
+                    if port and isinstance(d, DesignExternalPortDefinition):
+                        mod.add_port(
+                            Port(name=name, direction=dir, type=self._external_decl_type(d))
+                        )
+
+                    declared_exts[name] = (dir, port)
         return declared_exts
 
     def _parse_connections(
@@ -163,6 +187,8 @@ class DesignDescriptionFrontend:
 
     def _add_ports(self, mod: Module, declared_exts: dict[str, tuple[PortDirection, bool]]):
         for name, (dir, port) in declared_exts.items():
+            if mod.ios.find_by_name(name) is not None:
+                continue
             if port:
                 mod.add_port(Port(name=name, direction=dir, type=Bit()))
             else:
@@ -220,7 +246,7 @@ class DesignDescriptionFrontend:
 
         # Gather declarations of external ports and interfaces so that
         # they can be instantiated with the inferred type later on
-        declared_exts = self._parse_ports(desc)
+        declared_exts = self._parse_ports(desc, mod)
         # Parse regular connections between ports, interfaces and externals
         self._parse_connections(desc, design, declared_exts)
 

--- a/topwrap/frontend/yaml/design_schema.py
+++ b/topwrap/frontend/yaml/design_schema.py
@@ -51,9 +51,18 @@ class DesignIP(MarshmallowDataclassExtensions):
 
 
 @marshmallow_dataclass.dataclass(frozen=True)
+class DesignExternalPortDefinition(MarshmallowDataclassExtensions):
+    name: str
+    bound: List[Tuple[Union[str, int], Union[str, int]]] = ext_field(list, inline_depth=1)
+
+
+DesignExternalPort = Union[str, DesignExternalPortDefinition]
+
+
+@marshmallow_dataclass.dataclass(frozen=True)
 class DesignExternalPorts(MarshmallowDataclassExtensions):
-    input: List[str] = ext_field(list, data_key="in")
-    output: List[str] = ext_field(list, data_key="out")
+    input: List[DesignExternalPort] = ext_field(list, data_key="in")
+    output: List[DesignExternalPort] = ext_field(list, data_key="out")
     inout: List[Tuple[str, str]] = ext_field(list, inline_depth=1)
 
     @cached_property

--- a/topwrap/frontend/yaml/ip_core.py
+++ b/topwrap/frontend/yaml/ip_core.py
@@ -5,6 +5,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    cast,
 )
 
 from topwrap.backend.yaml.common.interface_schema import InterfaceModeDescription
@@ -122,10 +123,17 @@ class IPCoreDescriptionFrontend:
             if signal.name is not None:
                 slice = None if signal.slice is None else to_dims(signal.slice)
                 if signal.type is None:
-                    if signal.bound is None:
+                    bounds = signal.bound
+                    if bounds is None:
                         type = Bit()
                     else:
-                        type = Bits(dimensions=[to_dims(signal.bound)])
+                        if not isinstance(bounds[0], tuple):
+                            bounds = (cast(tuple[str | int, str | int], bounds),)
+                        type = Bits(
+                            dimensions=[
+                                to_dims(dim) for dim in cast(Sequence[Sequence[str | int]], bounds)
+                            ]
+                        )
                 else:
                     if signal.type not in types:
                         raise IPCoreDescriptionFrontendException(


### PR DESCRIPTION
Add support for multidimensional design and IP ports.
This is achieved by using the `bound` property to specify the port dimensions.